### PR TITLE
Add currenttag section by tagbar

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ call dein#add('itchyny/lightline.vim')
 " optional
 call dein#add('ryanoasis/vim-devicons')
 call dein#add('w0rp/ale')
+call dein#add('majutsushi/tagbar')
 ```
 
 #### TOML setting
@@ -69,6 +70,9 @@ repo = 'ryanoasis/vim-devicons'
 
 [[plugins]]
 repo = 'w0rp/ale'
+
+[[plugins]]
+repo = 'majutsushi/tagbar'
 ```
 
 [dein]: https://github.com/Shougo/dein.vim
@@ -116,3 +120,11 @@ let g:ale_statusline_format = [
       \ g:ale_echo_msg_warning_str . ' %d',
       \ nr2char(0xf4a1) . '  ']
 ```
+
+## tagbar setting (optional)
+
+lightline-delphinus can detect installed [tagbar][] and show function names on cursor by `tagbar#current()`.
+
+[tagbar]: https://github.com/majutsushi/tagbar
+
+<img width="621" alt="2018-07-12 14 22 05" src="https://user-images.githubusercontent.com/1239245/42614066-2914af50-85df-11e8-9465-395a04e6ac82.png">

--- a/autoload/lightline/delphinus/components.vim
+++ b/autoload/lightline/delphinus/components.vim
@@ -2,7 +2,7 @@
 " Filename: autoload/lightline/delphinus/components.vim
 " Author: delphinus
 " License: MIT License
-" Last Change: 2018-07-09T23:24:39+0900.
+" Last Change: 2018-07-12T14:15:00+0900.
 " =============================================================================
 
 scriptencoding utf-8
@@ -189,4 +189,24 @@ function! lightline#delphinus#components#percent() abort
   let line = &filetype ==# 'denite' ? denite#get_status('line_cursor') : line('.')
   let total = &filetype ==# 'denite' ? denite#get_status('line_total') : line('$')
   return total ? printf('%d%%', 100 * line / total) : '0%'
+endfunction
+
+function! lightline#delphinus#components#currenttag() abort
+  if !get(s:, 'currenttag_init')
+    try
+      let tmp = tagbar#currenttag('%', '', '')
+    catch
+    endtry
+    unlet! tmp
+    let s:currenttag_init = 1
+  endif
+  if !exists('*tagbar#currenttag')
+    return ''
+  endif
+  let now = localtime()
+  if get(s:, 'currenttag_last_lookup') != now
+    let s:currenttag_last_lookup = now
+    let s:currenttag_last_seen = tagbar#currenttag('%s', '')
+  endif
+  return get(s:, 'currenttag_last_seen', '')
 endfunction

--- a/plugin/lightline_delphinus.vim
+++ b/plugin/lightline_delphinus.vim
@@ -2,7 +2,7 @@
 " Filename: plugin/lightline_delphinus.vim
 " Author: delphinus
 " License: MIT License
-" Last Change: 2017-12-28T16:21:50+0900.
+" Last Change: 2018-07-12T14:02:38+0900.
 " =============================================================================
 
 scriptencoding utf-8
@@ -35,7 +35,7 @@ let g:lightline = {
         \ 'colorscheme': g:lightline_delphinus_colorscheme,
         \ 'mode_map': {'c': 'NORMAL'},
         \ 'active': {
-        \   'left': [ [ 'mode', 'paste' ], [ 'fugitive' ], [ 'filepath' ], [ 'filename' ] ],
+        \   'left': [ [ 'mode', 'paste' ], [ 'fugitive' ], [ 'filepath' ], [ 'filename', 'currenttag' ] ],
         \   'right': [
         \     [ 'lineinfo' ],
         \     [ 'percent' ],
@@ -59,6 +59,7 @@ let g:lightline = {
         \   'char_code':    'lightline#delphinus#components#charcode',
         \   'lineinfo':     'lightline#delphinus#components#lineinfo',
         \   'percent':      'lightline#delphinus#components#percent',
+        \   'currenttag':   'lightline#delphinus#components#currenttag',
         \ },
         \ 'component_function_visible_condition': {
         \   'mode': 1,


### PR DESCRIPTION
Add function names on cursor by `tagbar#current`.  The idea is from airline ([tagbar.vim][])

[tagbar.vim]: https://github.com/vim-airline/vim-airline/blob/master/autoload/airline/extensions/tagbar.vim