### PR TITLE
Fix windows compatibility filepath treat and shellslash option

### DIFF
--- a/autoload/lightline/delphinus/components.vim
+++ b/autoload/lightline/delphinus/components.vim
@@ -49,9 +49,16 @@ function! lightline#delphinus#components#filepath() abort
   if &filetype ==# 'vimfilter' || &filetype ==# 'unite' || winwidth(0) < 70
     let path_string = ''
   else
-    let path_string = substitute(expand('%:h'), $HOME, '~', '')
+    if exists('+shellslash')
+      let saved_shellslash = &shellslash
+      set shellslash
+    endif
+    let path_string = substitute(fnamemodify(expand('%:h'),':p'), fnamemodify(expand($HOME),':p'), '~/', '')
     if winwidth(0) < 120 && len(path_string) > 30
       let path_string = substitute(path_string, '\v([^/])[^/]*%(/)@=', '\1', 'g')
+    endif
+    if exists('+shellslash')
+      let &shellslash = saved_shellslash
     endif
   endif
 


### PR DESCRIPTION
Windowsでのfilepath動作が的確ではないようだったので修正してみました。
これでディレクトリ表示もスラッシュ統一されて出ます。

* shellslash設定
* %:h (ファイルパス)や$HOMEについてexpand後fnamemodifyしてバックスラッシュ混在を解決
* shellslash戻す

としています。

逆に*nix環境での確認が不十分なところはありますので、そういう環境で問題なければ取り込んでいただければな、と思います。