### PR TITLE
Fix windows compatibility filepath treat and shellslash option (relpath)

### DIFF
--- a/autoload/lightline/delphinus/components.vim
+++ b/autoload/lightline/delphinus/components.vim
@@ -49,9 +49,16 @@ function! lightline#delphinus#components#filepath() abort
   if &filetype ==# 'vimfilter' || &filetype ==# 'unite' || winwidth(0) < 70
     let path_string = ''
   else
-    let path_string = substitute(expand('%:h'), $HOME, '~', '')
+    if exists('+shellslash')
+      let saved_shellslash = &shellslash
+      set shellslash
+    endif
+    let path_string = substitute(expand('%:h'), fnamemodify(expand($HOME),''), '~', '')
     if winwidth(0) < 120 && len(path_string) > 30
       let path_string = substitute(path_string, '\v([^/])[^/]*%(/)@=', '\1', 'g')
+    endif
+    if exists('+shellslash')
+      let &shellslash = saved_shellslash
     endif
   endif
 


### PR DESCRIPTION
#11 のPRの修正版

カレントディレクトリによって表示が変わる今の仕組みを維持するようにしました。

`expand('%:h')`をfnamemodifyで正規化せずに、カレントからの相対パスとし、またホームの扱いを微調整して仕様を合せられた、と思います。
